### PR TITLE
[MUYAHO-1] 업비트에서 거래중인 종목명과 종목 코드를 스케줄링을 통해 갱신하는 기능 추가.

### DIFF
--- a/muyaho-api/src/main/java/com/depromeet/muyaho/ApiApplication.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/ApiApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class ApiApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ApiApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ApiApplication.class, args);
+    }
 
 }

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/config/schedule/SchedulingConfig.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/config/schedule/SchedulingConfig.java
@@ -1,0 +1,24 @@
+package com.depromeet.muyaho.config.schedule;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@EnableScheduling
+@Configuration
+public class SchedulingConfig implements SchedulingConfigurer {
+
+    private static final int POOL_SIZE = 2;
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+        threadPoolTaskScheduler.setPoolSize(POOL_SIZE);
+        threadPoolTaskScheduler.setThreadNamePrefix("myaho-scheduled-task-pool-");
+        threadPoolTaskScheduler.initialize();
+        taskRegistrar.setTaskScheduler(threadPoolTaskScheduler);
+    }
+
+}

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/controller/stock/StockController.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/controller/stock/StockController.java
@@ -2,7 +2,6 @@ package com.depromeet.muyaho.controller.stock;
 
 import com.depromeet.muyaho.controller.ApiResponse;
 import com.depromeet.muyaho.domain.stock.StockMarketType;
-import com.depromeet.muyaho.service.stock.StockBatchService;
 import com.depromeet.muyaho.service.stock.StockService;
 import com.depromeet.muyaho.service.stock.dto.response.StockInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,15 +16,7 @@ import java.util.List;
 @RestController
 public class StockController {
 
-    private final StockBatchService stockBatchService;
     private final StockService stockService;
-
-    @Operation(summary = "비트코인 주식 종목 리스트를 갱신하는 API", description = "차후 관리자 서버에 둘 예정")
-    @GetMapping("/api/v1/renew/bitcoin")
-    public ApiResponse<String> refreshBitCoinStock() {
-        stockBatchService.renewBitCoin();
-        return ApiResponse.SUCCESS;
-    }
 
     @Operation(summary = "비트코인 종목 코드/명을 조회하는 API")
     @GetMapping("/api/v1/stock/list")

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/external/bithumb/WebClientBithumbApiCallerImpl.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/external/bithumb/WebClientBithumbApiCallerImpl.java
@@ -4,11 +4,13 @@ import com.depromeet.muyaho.exception.BadGatewayException;
 import com.depromeet.muyaho.external.bithumb.dto.component.BithumbTradeComponent;
 import com.depromeet.muyaho.external.bithumb.dto.response.BithumbTradeInfoResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class WebClientBithumbApiCallerImpl implements BithumbApiCaller {
@@ -18,6 +20,7 @@ public class WebClientBithumbApiCallerImpl implements BithumbApiCaller {
 
     @Override
     public BithumbTradeInfoResponse retrieveTrades(String marketCode) {
+        log.info("빗썸 가격정보 조회 요청 API 사용 marketCode: {}", marketCode);
         return webClient.get()
             .uri(bithumbTradeComponent.getUrl().concat("/").concat(marketCode))
             .retrieve()

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/external/upbit/WebClientUpBitApiCallerImpl.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/external/upbit/WebClientUpBitApiCallerImpl.java
@@ -7,6 +7,7 @@ import com.depromeet.muyaho.external.upbit.dto.component.UpBitTradeComponent;
 import com.depromeet.muyaho.external.upbit.dto.response.UpBitMarketResponse;
 import com.depromeet.muyaho.external.upbit.dto.response.UpBitTradeInfoResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -15,6 +16,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class WebClientUpBitApiCallerImpl implements UpBitApiCaller {
@@ -25,6 +27,7 @@ public class WebClientUpBitApiCallerImpl implements UpBitApiCaller {
 
     @Override
     public List<UpBitMarketResponse> retrieveMarkets() {
+        log.info("업비트 현재 거래되는 종목명/코드 조회 요청 API 사용");
         return webClient.get()
             .uri(marketsComponent.getUrl())
             .retrieve()
@@ -36,6 +39,7 @@ public class WebClientUpBitApiCallerImpl implements UpBitApiCaller {
 
     @Override
     public List<UpBitTradeInfoResponse> retrieveTrades(String marketCode) {
+        log.info("업비트 가격정보 조회 요청 API 사용 marketCode: {}", marketCode);
         return webClient.get()
             .uri(tickerComponent.getUrl(), uriBuilder -> uriBuilder.queryParam("markets", marketCode).build())
             .retrieve()

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/schedule/BitCoinScheduler.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/schedule/BitCoinScheduler.java
@@ -1,28 +1,33 @@
-package com.depromeet.muyaho.service.stock;
+package com.depromeet.muyaho.schedule;
 
 import com.depromeet.muyaho.domain.stock.StockMarketType;
 import com.depromeet.muyaho.event.stock.RequestedRenewEvent;
-import com.depromeet.muyaho.service.stock.dto.request.StockInfoRequest;
 import com.depromeet.muyaho.external.upbit.UpBitApiCaller;
+import com.depromeet.muyaho.service.stock.dto.request.StockInfoRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @RequiredArgsConstructor
-@Service
-public class StockBatchService {
+@Component
+public class BitCoinScheduler {
 
     private final ApplicationEventPublisher eventPublisher;
     private final UpBitApiCaller upBitApiCaller;
 
-    public void renewBitCoin() {
+    @Scheduled(cron = "0 0 * * * *")
+    public void renewUpBitTradingMarketCodes() {
         List<StockInfoRequest> stockInfoList = upBitApiCaller.retrieveMarkets().stream()
             .map(market -> StockInfoRequest.of(market.getMarket(), market.getKoreanName()))
             .collect(Collectors.toList());
         eventPublisher.publishEvent(RequestedRenewEvent.of(StockMarketType.BITCOIN, stockInfoList));
+        log.info("비트코인 종목 정보를 갱신합니다. 현재 {} 개의 종목 코드가 거래되고 있습니다", stockInfoList.size());
     }
 
 }


### PR DESCRIPTION
- [x] 매 시간마다 업비트에서 현재 거래하고 있는 종목명과 종목 코드들을 조회해서 우리 DB에 갱신한다.
- [x] 이때 신규로 추가되거나 다시 추가된 종목은 ACTIVE로 추가되고, 사라진 종목은 DISABLE 처리된다.