### PR TITLE
[MUYAHO-5] 종목 조회시 허용된 통화(Currency)만 조회 및 갱신되도록 수정.

### DIFF
--- a/muyaho-api/src/main/java/com/depromeet/muyaho/service/stock/StockService.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/service/stock/StockService.java
@@ -1,9 +1,6 @@
 package com.depromeet.muyaho.service.stock;
 
-import com.depromeet.muyaho.domain.stock.Stock;
-import com.depromeet.muyaho.domain.stock.StockCollection;
-import com.depromeet.muyaho.domain.stock.StockMarketType;
-import com.depromeet.muyaho.domain.stock.StockRepository;
+import com.depromeet.muyaho.domain.stock.*;
 import com.depromeet.muyaho.service.stock.dto.request.StockInfoRequest;
 import com.depromeet.muyaho.service.stock.dto.response.StockInfoResponse;
 import lombok.RequiredArgsConstructor;
@@ -27,11 +24,20 @@ public class StockService {
 
         final Map<String, Stock> stockMap = stockCollection.getStockMap();
         List<Stock> stockList = stockInfos.stream()
+            .filter(stock -> isAllowedCurrency(type, stock.getCode()))
             .map(stock -> stockMap.getOrDefault(stock.getCode(), Stock.newInstance(type, stock.getCode(), stock.getName())))
             .map(Stock::active)
             .collect(Collectors.toList());
-        
+
         stockRepository.saveAll(stockList);
+    }
+
+    private boolean isAllowedCurrency(StockMarketType type, String code) {
+        if (type.isAllowAll()) {
+            return true;
+        }
+        return type.getAllowedCurrencies().stream()
+            .anyMatch(code::startsWith);
     }
 
     @Transactional(readOnly = true)

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/service/stock/StockServiceUtils.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/service/stock/StockServiceUtils.java
@@ -16,4 +16,5 @@ public class StockServiceUtils {
         }
         return stock;
     }
+
 }

--- a/muyaho-api/src/test/java/com/depromeet/muyaho/service/stock/StockServiceTest.java
+++ b/muyaho-api/src/test/java/com/depromeet/muyaho/service/stock/StockServiceTest.java
@@ -32,6 +32,45 @@ class StockServiceTest {
         stockRepository.deleteAll();
     }
 
+    @Test
+    void 종목_갱신시_허용된_통화만_등록된다() {
+        // given
+        String allowedCode = "KRW-ABC";
+        String disAllowedCode = "ABC";
+
+        // when
+        stockService.renewStock(StockMarketType.BITCOIN, Arrays.asList(
+            StockInfoRequest.of(allowedCode, "허용된 비트코인"),
+            StockInfoRequest.of(disAllowedCode, "허용되지 않은 비트코인")));
+
+        // then
+        List<Stock> stockList = stockRepository.findAll();
+        assertThat(stockList).hasSize(1);
+        assertThat(stockList.get(0).getCode()).isEqualTo(allowedCode);
+        assertThat(stockList.get(0).getStatus()).isEqualTo(StockStatus.ACTIVE);
+    }
+
+    @Test
+    void 따로_제한이_없는경우_모두_등록된다() {
+        // given
+        String allowedCode1 = "Code1";
+        String allowedCode2 = "StockCode1";
+
+        // when
+        stockService.renewStock(StockMarketType.DOMESTIC_STOCK, Arrays.asList(
+            StockInfoRequest.of(allowedCode1, "제한 없는 국내 주식"),
+            StockInfoRequest.of(allowedCode2, "제한 없는 국내 주식")));
+
+        // then
+        List<Stock> stockList = stockRepository.findAll();
+        assertThat(stockList).hasSize(2);
+        assertThat(stockList.get(0).getCode()).isEqualTo(allowedCode1);
+        assertThat(stockList.get(0).getStatus()).isEqualTo(StockStatus.ACTIVE);
+
+        assertThat(stockList.get(1).getCode()).isEqualTo(allowedCode2);
+        assertThat(stockList.get(1).getStatus()).isEqualTo(StockStatus.ACTIVE);
+    }
+
     @MethodSource("각각_타입의_주식_리스트")
     @ParameterizedTest
     void 주식종목_갱신시_새롭게_상장된_주식의_경우_활성화로_새롭게_저장된다(String code, String name, StockMarketType type) {
@@ -74,12 +113,11 @@ class StockServiceTest {
         assertStock(stockList.get(0), code, name, type, StockStatus.ACTIVE);
     }
 
-    @MethodSource("각각_타입의_주식_리스트")
-    @ParameterizedTest
+    @Test
     void 주식종목을_갱신요청할때_기존에_있었는데_나오는경우_활성화로_유지된다() {
         // given
-        String code = "code";
-        String name = "새로운 주식";
+        String code = "KRW-code";
+        String name = "새로운 비트코인";
         StockMarketType type = StockMarketType.BITCOIN;
         stockRepository.save(StockCreator.createActive(code, name, type));
 
@@ -94,7 +132,7 @@ class StockServiceTest {
 
     private static Stream<Arguments> 각각_타입의_주식_리스트() {
         return Stream.of(
-            Arguments.of("bit", "비트코인", StockMarketType.BITCOIN),
+            Arguments.of("KRW-BTC", "비트코인", StockMarketType.BITCOIN),
             Arguments.of("oversea", "해외주식", StockMarketType.OVERSEAS_STOCK),
             Arguments.of("domestic", "국내주식", StockMarketType.DOMESTIC_STOCK)
         );
@@ -117,7 +155,7 @@ class StockServiceTest {
 
     private static Stream<Arguments> 비트코인과_해외주식_주식_리스트() {
         return Stream.of(
-            Arguments.of("code", "비트코인", StockMarketType.BITCOIN),
+            Arguments.of("KRW-BTC", "비트코인", StockMarketType.BITCOIN),
             Arguments.of("code", "해외주식", StockMarketType.OVERSEAS_STOCK)
         );
     }
@@ -148,6 +186,37 @@ class StockServiceTest {
 
         // then
         assertThat(responseList).isEmpty();
+    }
+
+    @Test
+    void 해당_타입에서_허용된_통화만_불러온다() {
+        // given
+        Stock stock1 = StockCreator.createActive("KRW-ABC", "허용된 비트코인", StockMarketType.BITCOIN);
+        Stock stock2 = StockCreator.createActive("ABC", "허용되지 않은 비트코인", StockMarketType.BITCOIN);
+        stockRepository.saveAll(Arrays.asList(stock1, stock2));
+
+        // when
+        List<StockInfoResponse> responseList = stockService.retrieveStockInfo(StockMarketType.BITCOIN);
+
+        // then
+        assertThat(responseList).hasSize(1);
+        assertThat(responseList.get(0).getCode()).isEqualTo(stock1.getCode());
+    }
+
+    @Test
+    void 따로_통화_제한이_없는경우_활성화된_모든_주식을_조회한다() {
+        // given
+        Stock stock1 = StockCreator.createActive("KRW-ABC", "제한 없는 국내주식", StockMarketType.DOMESTIC_STOCK);
+        Stock stock2 = StockCreator.createActive("ABC", "제한 없는 국내주식", StockMarketType.DOMESTIC_STOCK);
+        stockRepository.saveAll(Arrays.asList(stock1, stock2));
+
+        // when
+        List<StockInfoResponse> responseList = stockService.retrieveStockInfo(StockMarketType.DOMESTIC_STOCK);
+
+        // then
+        assertThat(responseList).hasSize(2);
+        assertThat(responseList.get(0).getCode()).isEqualTo(stock1.getCode());
+        assertThat(responseList.get(1).getCode()).isEqualTo(stock2.getCode());
     }
 
     private void assertStock(Stock stock, String code, String name, StockMarketType type, StockStatus status) {

--- a/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/stock/StockMarketType.java
+++ b/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/stock/StockMarketType.java
@@ -1,9 +1,23 @@
 package com.depromeet.muyaho.domain.stock;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
 public enum StockMarketType {
 
-    DOMESTIC_STOCK,
-    OVERSEAS_STOCK,
-    BITCOIN
+    DOMESTIC_STOCK(Collections.emptyList()),
+    OVERSEAS_STOCK(Collections.emptyList()),
+    BITCOIN(Collections.singletonList("KRW-"));
+
+    private final List<String> allowedCurrencies;
+
+    public boolean isAllowAll() {
+        return this.allowedCurrencies.isEmpty();
+    }
 
 }

--- a/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/stock/repository/StockRepositoryCustomImpl.java
+++ b/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/stock/repository/StockRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package com.depromeet.muyaho.domain.stock.repository;
 import com.depromeet.muyaho.domain.stock.Stock;
 import com.depromeet.muyaho.domain.stock.StockMarketType;
 import com.depromeet.muyaho.domain.stock.StockStatus;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -28,17 +29,27 @@ public class StockRepositoryCustomImpl implements StockRepositoryCustom {
         return queryFactory.selectFrom(stock)
             .where(
                 stock.type.eq(type),
-                stock.status.eq(StockStatus.ACTIVE)
+                stock.status.eq(StockStatus.ACTIVE),
+                filterCurrency(type.getAllowedCurrencies())
             )
             .orderBy(stock.id.asc())
             .fetch();
+    }
+
+    private BooleanBuilder filterCurrency(List<String> allowedCurrencies) {
+        BooleanBuilder builder = new BooleanBuilder();
+        for (String allowedCurrency : allowedCurrencies) {
+            builder.or(stock.code.startsWith(allowedCurrency));
+        }
+        return builder;
     }
 
     @Override
     public Stock findStockById(Long stockId) {
         return queryFactory.selectFrom(stock)
             .where(
-                stock.id.eq(stockId)
+                stock.id.eq(stockId),
+                stock.status.eq(StockStatus.ACTIVE)
             ).fetchOne();
     }
 

--- a/muyaho-domain/src/test/java/com/depromeet/muyaho/domain/stock/StockRepositoryTest.java
+++ b/muyaho-domain/src/test/java/com/depromeet/muyaho/domain/stock/StockRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.depromeet.muyaho.domain.stock;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class StockRepositoryTest {
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @AfterEach
+    void cleanUp() {
+        stockRepository.deleteAll();
+    }
+
+    @Test
+    void 비트코인_허용된_통화만_조회된다() {
+        // given
+        StockMarketType type = StockMarketType.BITCOIN;
+        Stock allowedStock = StockCreator.createActive("KRW-ABC", "허용된 비트코인", type);
+        Stock notAllowedStock = StockCreator.createActive("ABC", "허용되지 않은 비트코인", type);
+        stockRepository.saveAll(Arrays.asList(allowedStock, notAllowedStock));
+
+        // when
+        List<Stock> stockList = stockRepository.findAllActiveStockByType(type);
+
+        // then
+        assertThat(stockList).hasSize(1);
+        assertThat(stockList.get(0).getCode()).isEqualTo(allowedStock.getCode());
+    }
+
+    @Test
+    void 국내주식_허용된_통화만_조회된다() {
+        // given
+        StockMarketType type = StockMarketType.DOMESTIC_STOCK;
+        Stock stock = StockCreator.createActive("code", "code", type);
+        stockRepository.save(stock);
+
+        // when
+        List<Stock> stockList = stockRepository.findAllActiveStockByType(type);
+
+        // then
+        assertThat(stockList).hasSize(1);
+    }
+
+}


### PR DESCRIPTION
비트코인 종목 조회시 KRW, BTC 등 여러 통화별로 모두 조회되는 문제점 발생해서 해결.