### PR TITLE
[MUYAHO-8] 국내/해외 주식 연동

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - feature/8
 jobs:
   build:
     runs-on: ubuntu-18.04

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/config/webclient/WebClientConfig.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/config/webclient/WebClientConfig.java
@@ -5,6 +5,7 @@ import io.netty.handler.timeout.ReadTimeoutHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.tcp.TcpClient;
@@ -17,12 +18,17 @@ public class WebClientConfig {
     @Bean
     public WebClient webClient() {
         return WebClient.builder()
+            .exchangeStrategies(ExchangeStrategies.builder()
+                .codecs(configurer -> configurer
+                    .defaultCodecs()
+                    .maxInMemorySize(16 * 1024 * 1024))
+                .build())
             .clientConnector(new ReactorClientHttpConnector(
                 HttpClient.from(
                     TcpClient.create()
-                        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3000)
+                        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
                         .doOnConnected(conn ->
-                            conn.addHandler(new ReadTimeoutHandler(3000, TimeUnit.MILLISECONDS))
+                            conn.addHandler(new ReadTimeoutHandler(10000, TimeUnit.MILLISECONDS))
                         )
                 )
             )).build();

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/controller/MainController.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/controller/MainController.java
@@ -5,13 +5,21 @@ import com.depromeet.muyaho.config.session.SessionConstants;
 import com.depromeet.muyaho.domain.member.Member;
 import com.depromeet.muyaho.domain.member.MemberProvider;
 import com.depromeet.muyaho.domain.member.MemberRepository;
+import com.depromeet.muyaho.domain.stock.StockMarketType;
+import com.depromeet.muyaho.event.stock.RequestedRenewEvent;
+import com.depromeet.muyaho.external.stock.StockApiCaller;
+import com.depromeet.muyaho.external.stock.StockType;
+import com.depromeet.muyaho.service.stock.dto.request.StockInfoRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpSession;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @RestController
@@ -20,6 +28,8 @@ public class MainController {
     private final MemberRepository memberRepository;
     private final HttpSession httpSession;
     private static final Member testMember = Member.newInstance("test-uid", null, "테스트 계정", null, MemberProvider.KAKAO);
+    private final StockApiCaller stockApiCaller;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Operation(summary = "Health Check")
     @GetMapping("/ping")
@@ -28,6 +38,7 @@ public class MainController {
     }
 
     // 차후 연동 후 삭제
+    @Deprecated
     @Operation(summary = "(테스트용) 세션을 받아오는 API (Deprecated)", description = "차후 연동 후 사라질 예정")
     @Profile({"local", "dev"})
     @GetMapping("/test-session")
@@ -38,6 +49,28 @@ public class MainController {
         }
         httpSession.setAttribute(SessionConstants.AUTH_SESSION, MemberSession.of(findMember.getId()));
         return ApiResponse.success(httpSession.getId());
+    }
+
+    @Deprecated
+    @Profile({"local", "dev"})
+    @GetMapping("/renew-domestic")
+    public String renewDomesticStocks() {
+        List<StockInfoRequest> stockInfoList = stockApiCaller.getStockCodes(StockType.DOMESTIC_STOCK).stream()
+            .map(market -> StockInfoRequest.of(market.getCode(), market.getName()))
+            .collect(Collectors.toList());
+        eventPublisher.publishEvent(RequestedRenewEvent.of(StockMarketType.DOMESTIC_STOCK, stockInfoList));
+        return "OK";
+    }
+
+    @Deprecated
+    @Profile({"local", "dev"})
+    @GetMapping("/renew-overseas")
+    public String renewOverseaStocks() {
+        List<StockInfoRequest> stockInfoList = stockApiCaller.getStockCodes(StockType.OVERSEAS_STOCK).stream()
+            .map(market -> StockInfoRequest.of(market.getCode(), market.getName()))
+            .collect(Collectors.toList());
+        eventPublisher.publishEvent(RequestedRenewEvent.of(StockMarketType.OVERSEAS_STOCK, stockInfoList));
+        return "OK";
     }
 
 }

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/controller/member/MemberController.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/controller/member/MemberController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -35,7 +36,8 @@ public class MemberController {
         return ApiResponse.success(memberService.updateMemberInfo(request, memberId));
     }
 
-    @Operation(summary = "회원탈퇴 API", security = {@SecurityRequirement(name = "Authorization")}, parameters = @Parameter(name = "Authorization"))
+    @Profile({"local", "dev"})
+    @Operation(summary = "회원탈퇴 API (테스트용)", security = {@SecurityRequirement(name = "Authorization")}, parameters = @Parameter(name = "Authorization"))
     @Auth
     @DeleteMapping("/api/v1/member")
     public ApiResponse<String> deleteMemberInfo(@MemberId Long memberId) {

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/controller/memberstock/MemberStockController.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/controller/memberstock/MemberStockController.java
@@ -3,6 +3,7 @@ package com.depromeet.muyaho.controller.memberstock;
 import com.depromeet.muyaho.config.interceptor.Auth;
 import com.depromeet.muyaho.config.resolver.MemberId;
 import com.depromeet.muyaho.controller.ApiResponse;
+import com.depromeet.muyaho.domain.stock.StockMarketType;
 import com.depromeet.muyaho.service.memberstock.MemberStockRetrieveService;
 import com.depromeet.muyaho.service.memberstock.MemberStockService;
 import com.depromeet.muyaho.service.memberstock.dto.request.AddMemberStockRequest;
@@ -36,8 +37,8 @@ public class MemberStockController {
     @Operation(summary = "내가 소유한 주식들을 조회하는 API", security = {@SecurityRequirement(name = "Authorization")}, parameters = @Parameter(name = "Authorization"))
     @Auth
     @GetMapping("/api/v1/member/stock/bitcoin")
-    public ApiResponse<List<MemberStockCurrentInfoResponse>> getMyBitCoinStocks(@MemberId Long memberId) {
-        return ApiResponse.success(memberStockRetrieveService.getMyBitCoinStock(memberId));
+    public ApiResponse<List<MemberStockCurrentInfoResponse>> getStocksInfo(@RequestParam StockMarketType type, @MemberId Long memberId) {
+        return ApiResponse.success(memberStockRetrieveService.getStocksInfo(type, memberId));
     }
 
     @Operation(summary = "내가 소유한 주식들을 수정하는 API", security = {@SecurityRequirement(name = "Authorization")}, parameters = @Parameter(name = "Authorization"))

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/controller/stock/StockController.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/controller/stock/StockController.java
@@ -18,7 +18,7 @@ public class StockController {
 
     private final StockService stockService;
 
-    @Operation(summary = "비트코인 종목 코드/명을 조회하는 API")
+    @Operation(summary = "주식 종목 코드와 종목명을 조회하는 API", description = "DOMESTIC_STOCK, OVERSEAS_STOCK, BITCOIN")
     @GetMapping("/api/v1/stock/list")
     public ApiResponse<List<StockInfoResponse>> retrieveStocks(@RequestParam StockMarketType type) {
         return ApiResponse.success(stockService.retrieveStockInfo(type));

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/StockApiCaller.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/StockApiCaller.java
@@ -1,0 +1,11 @@
+package com.depromeet.muyaho.external.stock;
+
+import com.depromeet.muyaho.external.stock.dto.response.StockCodeResponse;
+
+import java.util.List;
+
+public interface StockApiCaller {
+
+    List<StockCodeResponse> getStockCodes(StockType type);
+    
+}

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/StockApiCaller.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/StockApiCaller.java
@@ -1,11 +1,14 @@
 package com.depromeet.muyaho.external.stock;
 
 import com.depromeet.muyaho.external.stock.dto.response.StockCodeResponse;
+import com.depromeet.muyaho.external.stock.dto.response.StockPriceResponse;
 
 import java.util.List;
 
 public interface StockApiCaller {
 
     List<StockCodeResponse> getStockCodes(StockType type);
-    
+
+    List<StockPriceResponse> getStockPrice(String codes);
+
 }

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/StockType.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/StockType.java
@@ -1,0 +1,15 @@
+package com.depromeet.muyaho.external.stock;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StockType {
+
+    DOMESTIC_STOCK("KRX"),
+    OVERSEAS_STOCK("NASDAQ");
+
+    private final String type;
+
+}

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/WebClientStockApiCallerImpl.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/WebClientStockApiCallerImpl.java
@@ -1,0 +1,36 @@
+package com.depromeet.muyaho.external.stock;
+
+import com.depromeet.muyaho.exception.BadGatewayException;
+import com.depromeet.muyaho.external.stock.dto.component.StockCodeComponent;
+import com.depromeet.muyaho.external.stock.dto.response.StockCodeResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class WebClientStockApiCallerImpl implements StockApiCaller {
+
+    private final StockCodeComponent stockCodeComponent;
+    private final WebClient webClient;
+
+    public List<StockCodeResponse> getStockCodes(StockType type) {
+        log.info("{} 주식 종목 코드/명 요청 API 사용", type);
+        return webClient.get()
+            .uri(String.format("%s?type=%s", stockCodeComponent.getUrl(), type.getType()))
+            .retrieve()
+            .onStatus(HttpStatus::isError, errorResponse -> Mono.error(new BadGatewayException(String.format("주식 (%s) 외부 API 연동 중 에러가 발생하였습니다", type))))
+            .bodyToMono(new ParameterizedTypeReference<List<StockCodeResponse>>() {
+            })
+            .block();
+    }
+
+}

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/WebClientStockApiCallerImpl.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/WebClientStockApiCallerImpl.java
@@ -2,11 +2,12 @@ package com.depromeet.muyaho.external.stock;
 
 import com.depromeet.muyaho.exception.BadGatewayException;
 import com.depromeet.muyaho.external.stock.dto.component.StockCodeComponent;
+import com.depromeet.muyaho.external.stock.dto.component.StockPriceComponent;
 import com.depromeet.muyaho.external.stock.dto.response.StockCodeResponse;
+import com.depromeet.muyaho.external.stock.dto.response.StockPriceResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -20,6 +21,7 @@ import java.util.List;
 public class WebClientStockApiCallerImpl implements StockApiCaller {
 
     private final StockCodeComponent stockCodeComponent;
+    private final StockPriceComponent stockPriceComponent;
     private final WebClient webClient;
 
     public List<StockCodeResponse> getStockCodes(StockType type) {
@@ -29,6 +31,16 @@ public class WebClientStockApiCallerImpl implements StockApiCaller {
             .retrieve()
             .onStatus(HttpStatus::isError, errorResponse -> Mono.error(new BadGatewayException(String.format("주식 (%s) 외부 API 연동 중 에러가 발생하였습니다", type))))
             .bodyToMono(new ParameterizedTypeReference<List<StockCodeResponse>>() {
+            })
+            .block();
+    }
+
+    public List<StockPriceResponse> getStockPrice(String codes) {
+        return webClient.get()
+            .uri(String.format("%s?codes=%s", stockPriceComponent.getUrl(), codes))
+            .retrieve()
+            .onStatus(HttpStatus::isError, errorResponse -> Mono.error(new BadGatewayException(String.format("주식 외부 API 연동 중 에러가 발생하였습니다"))))
+            .bodyToMono(new ParameterizedTypeReference<List<StockPriceResponse>>() {
             })
             .block();
     }

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/dto/component/StockCodeComponent.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/dto/component/StockCodeComponent.java
@@ -1,0 +1,18 @@
+package com.depromeet.muyaho.external.stock.dto.component;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ToString
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "stock")
+public class StockCodeComponent {
+
+    private String url;
+
+}

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/dto/component/StockPriceComponent.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/dto/component/StockPriceComponent.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Component;
 @Getter
 @Setter
 @Component
-@ConfigurationProperties(prefix = "stock.markets")
-public class StockCodeComponent {
+@ConfigurationProperties(prefix = "stock.trade")
+public class StockPriceComponent {
 
     private String url;
 

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/dto/response/StockCodeResponse.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/dto/response/StockCodeResponse.java
@@ -1,0 +1,18 @@
+package com.depromeet.muyaho.external.stock.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@ToString
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class StockCodeResponse {
+
+    @JsonProperty("Symbol")
+    private String code;
+
+    @JsonProperty("Name")
+    private String name;
+
+}

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/dto/response/StockPriceResponse.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/external/stock/dto/response/StockPriceResponse.java
@@ -1,0 +1,17 @@
+package com.depromeet.muyaho.external.stock.dto.response;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@ToString
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class StockPriceResponse {
+
+    private String code;
+
+    private BigDecimal price;
+
+}

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/schedule/BitCoinScheduler.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/schedule/BitCoinScheduler.java
@@ -2,6 +2,8 @@ package com.depromeet.muyaho.schedule;
 
 import com.depromeet.muyaho.domain.stock.StockMarketType;
 import com.depromeet.muyaho.event.stock.RequestedRenewEvent;
+import com.depromeet.muyaho.external.stock.StockApiCaller;
+import com.depromeet.muyaho.external.stock.StockType;
 import com.depromeet.muyaho.external.upbit.UpBitApiCaller;
 import com.depromeet.muyaho.service.stock.dto.request.StockInfoRequest;
 import lombok.RequiredArgsConstructor;
@@ -20,14 +22,37 @@ public class BitCoinScheduler {
 
     private final ApplicationEventPublisher eventPublisher;
     private final UpBitApiCaller upBitApiCaller;
+    private final StockApiCaller stockApiCaller;
 
     @Scheduled(cron = "0 0 * * * *")
     public void renewUpBitTradingMarketCodes() {
+        renewBitCoinCodes();
+        renewDomesticStockCodes();
+        renewOverseasStockCodes();
+    }
+
+    private void renewBitCoinCodes() {
         List<StockInfoRequest> stockInfoList = upBitApiCaller.retrieveMarkets().stream()
             .map(market -> StockInfoRequest.of(market.getMarket(), market.getKoreanName()))
             .collect(Collectors.toList());
         eventPublisher.publishEvent(RequestedRenewEvent.of(StockMarketType.BITCOIN, stockInfoList));
         log.info("비트코인 종목 정보를 갱신합니다. 현재 {} 개의 종목 코드가 거래되고 있습니다", stockInfoList.size());
+    }
+
+    private void renewDomesticStockCodes() {
+        List<StockInfoRequest> stockInfoList = stockApiCaller.getStockCodes(StockType.DOMESTIC_STOCK).stream()
+            .map(market -> StockInfoRequest.of(market.getCode(), market.getName()))
+            .collect(Collectors.toList());
+        eventPublisher.publishEvent(RequestedRenewEvent.of(StockMarketType.DOMESTIC_STOCK, stockInfoList));
+        log.info("국내주식 종목 정보를 갱신합니다. 현재 {} 개의 종목 코드가 거래되고 있습니다", stockInfoList.size());
+    }
+
+    private void renewOverseasStockCodes() {
+        List<StockInfoRequest> stockInfoList = stockApiCaller.getStockCodes(StockType.OVERSEAS_STOCK).stream()
+            .map(market -> StockInfoRequest.of(market.getCode(), market.getName()))
+            .collect(Collectors.toList());
+        eventPublisher.publishEvent(RequestedRenewEvent.of(StockMarketType.OVERSEAS_STOCK, stockInfoList));
+        log.info("해외주식 종목 정보를 갱신합니다. 현재 {} 개의 종목 코드가 거래되고 있습니다", stockInfoList.size());
     }
 
 }

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/service/memberstock/MemberStockRetrieveService.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/service/memberstock/MemberStockRetrieveService.java
@@ -4,6 +4,8 @@ import com.depromeet.muyaho.domain.memberstock.MemberStock;
 import com.depromeet.muyaho.domain.memberstock.MemberStockCollection;
 import com.depromeet.muyaho.domain.memberstock.MemberStockRepository;
 import com.depromeet.muyaho.domain.stock.StockMarketType;
+import com.depromeet.muyaho.external.stock.StockApiCaller;
+import com.depromeet.muyaho.external.stock.dto.response.StockPriceResponse;
 import com.depromeet.muyaho.external.upbit.UpBitApiCaller;
 import com.depromeet.muyaho.external.upbit.dto.response.UpBitTradeInfoResponse;
 import com.depromeet.muyaho.service.memberstock.dto.response.MemberStockCurrentInfoResponse;
@@ -22,21 +24,33 @@ public class MemberStockRetrieveService {
 
     private final MemberStockRepository memberStockRepository;
     private final UpBitApiCaller upBitApiCaller;
+    private final StockApiCaller stockApiCaller;
 
     @Transactional(readOnly = true)
-    public List<MemberStockCurrentInfoResponse> getMyBitCoinStock(Long memberId) {
-        MemberStockCollection collection = MemberStockCollection.of(memberStockRepository.findAllStocksByMemberIdAndType(memberId, StockMarketType.BITCOIN));
+    public List<MemberStockCurrentInfoResponse> getStocksInfo(StockMarketType type, Long memberId) {
+        MemberStockCollection collection = MemberStockCollection.of(memberStockRepository.findAllStocksByMemberIdAndType(memberId, type));
         if (collection.isEmpty()) {
             return Collections.emptyList();
         }
-        return retrieveCurrentPrice(collection);
+        if (type.equals(StockMarketType.BITCOIN)) {
+            return retrieveBitCoinCurrentPrice(collection);
+        }
+        return retrieveStockCurrentPrice(collection);
     }
 
-    private List<MemberStockCurrentInfoResponse> retrieveCurrentPrice(MemberStockCollection collection) {
+    private List<MemberStockCurrentInfoResponse> retrieveBitCoinCurrentPrice(MemberStockCollection collection) {
         final Map<String, MemberStock> memberStockMap = collection.newMemberStockMap();
         List<UpBitTradeInfoResponse> tradeInfoResponses = upBitApiCaller.retrieveTrades(collection.extractCodesWithDelimiter(","));
         return tradeInfoResponses.stream()
             .map(tradeInfoResponse -> MemberStockCurrentInfoResponse.of(memberStockMap.get(tradeInfoResponse.getMarket()), tradeInfoResponse.getTradePrice()))
+            .collect(Collectors.toList());
+    }
+
+    private List<MemberStockCurrentInfoResponse> retrieveStockCurrentPrice(MemberStockCollection collection) {
+        final Map<String, MemberStock> memberStockMap = collection.newMemberStockMap();
+        List<StockPriceResponse> stockPrices = stockApiCaller.getStockPrice(collection.extractCodesWithDelimiter(","));
+        return stockPrices.stream()
+            .map(tradeInfoResponse -> MemberStockCurrentInfoResponse.of(memberStockMap.get(tradeInfoResponse.getCode()), tradeInfoResponse.getPrice()))
             .collect(Collectors.toList());
     }
 

--- a/muyaho-api/src/main/resources/application-market.yml
+++ b/muyaho-api/src/main/resources/application-market.yml
@@ -7,3 +7,5 @@ bitcoin:
   bithumb:
     trade:
       url: https://api.bithumb.com/public/ticker
+stock:
+  url: http://muyaho-api-alb-302156047.ap-northeast-2.elb.amazonaws.com:5000/api/v1/stock/code

--- a/muyaho-api/src/main/resources/application-market.yml
+++ b/muyaho-api/src/main/resources/application-market.yml
@@ -8,4 +8,7 @@ bitcoin:
     trade:
       url: https://api.bithumb.com/public/ticker
 stock:
-  url: http://muyaho-api-alb-302156047.ap-northeast-2.elb.amazonaws.com:5000/api/v1/stock/code
+  markets:
+    url: http://muyaho-api-alb-302156047.ap-northeast-2.elb.amazonaws.com:5000/api/v1/stock/code
+  trade:
+    url: http://muyaho-api-alb-302156047.ap-northeast-2.elb.amazonaws.com:5000/api/v1/stock/price

--- a/muyaho-api/src/test/java/com/depromeet/muyaho/service/memberstock/MemberStockRetrieveServiceTest.java
+++ b/muyaho-api/src/test/java/com/depromeet/muyaho/service/memberstock/MemberStockRetrieveServiceTest.java
@@ -5,6 +5,10 @@ import com.depromeet.muyaho.domain.stock.Stock;
 import com.depromeet.muyaho.domain.stock.StockCreator;
 import com.depromeet.muyaho.domain.stock.StockMarketType;
 import com.depromeet.muyaho.domain.stock.StockRepository;
+import com.depromeet.muyaho.external.stock.StockApiCaller;
+import com.depromeet.muyaho.external.stock.StockType;
+import com.depromeet.muyaho.external.stock.dto.response.StockCodeResponse;
+import com.depromeet.muyaho.external.stock.dto.response.StockPriceResponse;
 import com.depromeet.muyaho.external.upbit.UpBitApiCaller;
 import com.depromeet.muyaho.external.upbit.dto.response.UpBitMarketResponse;
 import com.depromeet.muyaho.external.upbit.dto.response.UpBitTradeInfoResponse;
@@ -36,7 +40,7 @@ public class MemberStockRetrieveServiceTest extends MemberSetupTest {
 
     @BeforeEach
     void setUpStock() {
-        memberStockRetrieveService = new MemberStockRetrieveService(memberStockRepository, new StubUpBitApiCaller());
+        memberStockRetrieveService = new MemberStockRetrieveService(memberStockRepository, new StubUpBitApiCaller(), new StubStockApiCaller());
         stock = stockRepository.save(StockCreator.createActive("code", "비트코인", StockMarketType.BITCOIN));
     }
 
@@ -49,6 +53,18 @@ public class MemberStockRetrieveServiceTest extends MemberSetupTest {
         @Override
         public List<UpBitTradeInfoResponse> retrieveTrades(String marketCode) {
             return Collections.singletonList(UpBitTradeInfoResponse.testInstance(marketCode, 20000.5));
+        }
+    }
+
+    private static class StubStockApiCaller implements StockApiCaller {
+        @Override
+        public List<StockCodeResponse> getStockCodes(StockType type) {
+            return null;
+        }
+
+        @Override
+        public List<StockPriceResponse> getStockPrice(String codes) {
+            return null;
         }
     }
 
@@ -74,7 +90,7 @@ public class MemberStockRetrieveServiceTest extends MemberSetupTest {
         memberStockRepository.save(memberStock);
 
         // when
-        List<MemberStockCurrentInfoResponse> responses = memberStockRetrieveService.getMyBitCoinStock(memberId);
+        List<MemberStockCurrentInfoResponse> responses = memberStockRetrieveService.getStocksInfo(StockMarketType.BITCOIN, memberId);
 
         // then
         assertThat(responses).hasSize(1);
@@ -96,7 +112,7 @@ public class MemberStockRetrieveServiceTest extends MemberSetupTest {
         memberStockRepository.save(MemberStockCreator.create(999L, stock, 10000, 10));
 
         // when
-        List<MemberStockCurrentInfoResponse> responses = memberStockRetrieveService.getMyBitCoinStock(memberId);
+        List<MemberStockCurrentInfoResponse> responses = memberStockRetrieveService.getStocksInfo(StockMarketType.BITCOIN, memberId);
 
         // then
         assertThat(responses).isEmpty();
@@ -105,7 +121,7 @@ public class MemberStockRetrieveServiceTest extends MemberSetupTest {
     @Test
     void 아무_주식도_소유하고_있지않을때_조회하면_빈_리스트가_반환된다() {
         // when
-        List<MemberStockCurrentInfoResponse> responses = memberStockRetrieveService.getMyBitCoinStock(memberId);
+        List<MemberStockCurrentInfoResponse> responses = memberStockRetrieveService.getStocksInfo(StockMarketType.BITCOIN, memberId);
 
         // then
         assertThat(responses).isEmpty();


### PR DESCRIPTION
- [x] 국내 주식 종목 코드/ 종목 명 조회해서 DB에 저장. (스케줄링)
- [x] 해외 주식 종목 코드/ 종목 명 조회해서 DB에 저장. (스케줄링)
- [x] 사용자가 보유한 국내 주식의 현재가를 조회해서 결과 도출.
- [x]  사용자가 보유한 해외 주식의 현재가를 조회해서 결과 도출.