### PR TITLE
[MUYAHO-27] 현재 멤버가 보유한 주식 총액을 캐싱된 데이터를 먼저 가져올 수 있는 기능 추가.

### DIFF
--- a/muyaho-api/http/memberstock/memberstock.http
+++ b/muyaho-api/http/memberstock/memberstock.http
@@ -4,10 +4,10 @@ Content-Type: application/json
 Authorization: Bearer {{AUTHORIZATION}}
 
 {
-    "stockId": 1,
+    "stockId": 3310,
     "purchasePrice": 10000000,
     "quantity": 3,
-    "currencyType": "WON",
+    "currencyType": "DOLLAR",
     "purchaseTotalPrice": 1000
 }
 
@@ -16,7 +16,7 @@ GET {{api}}/api/v1/member/stock/status
 Authorization: Bearer {{AUTHORIZATION}}
 
 ### 내가 마지막으로 주식 정보를 가져오는 API
-GET {{api}}/api/v1/member/stock/status/previous
+GET {{api}}/api/v1/member/stock/status/history
 Authorization: Bearer {{AUTHORIZATION}}
 
 

--- a/muyaho-api/http/memberstock/memberstock.http
+++ b/muyaho-api/http/memberstock/memberstock.http
@@ -4,7 +4,7 @@ Content-Type: application/json
 Authorization: Bearer {{AUTHORIZATION}}
 
 {
-    "stockId": 2590,
+    "stockId": 1,
     "purchasePrice": 10000000,
     "quantity": 3,
     "currencyType": "WON",
@@ -12,7 +12,11 @@ Authorization: Bearer {{AUTHORIZATION}}
 }
 
 ### 내 주식 정보를 가져오는 API
-GET {{api}}/api/v1/stock/status
+GET {{api}}/api/v1/member/stock/status
+Authorization: Bearer {{AUTHORIZATION}}
+
+### 내가 마지막으로 주식 정보를 가져오는 API
+GET {{api}}/api/v1/member/stock/status/previous
 Authorization: Bearer {{AUTHORIZATION}}
 
 

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/controller/LocalTestController.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/controller/LocalTestController.java
@@ -40,7 +40,7 @@ public class LocalTestController {
 
     @GetMapping("/renew/stock")
     public String renewDomesticStocks() {
-//        scheduler.renewDomesticStocksCode();
+        scheduler.renewDomesticStocksCode();
         scheduler.renewBitCoinStocksCode();
         scheduler.renewOverseasStocksCode();
         return "OK";

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/controller/LocalTestController.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/controller/LocalTestController.java
@@ -40,7 +40,7 @@ public class LocalTestController {
 
     @GetMapping("/renew/stock")
     public String renewDomesticStocks() {
-        scheduler.renewDomesticStocksCode();
+//        scheduler.renewDomesticStocksCode();
         scheduler.renewBitCoinStocksCode();
         scheduler.renewOverseasStocksCode();
         return "OK";

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/controller/memberstock/MemberStockRetrieveController.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/controller/memberstock/MemberStockRetrieveController.java
@@ -23,7 +23,7 @@ public class MemberStockRetrieveController {
 
     private final MemberStockRetrieveService memberStockRetrieveService;
 
-    @Operation(summary = "내가 보유한 주식들을 조회하는 API", security = {@SecurityRequirement(name = "Authorization")}, parameters = @Parameter(name = "Authorization"))
+    @Operation(summary = "내가 보유한 특정 종류의 주식들을 조회하는 API", security = {@SecurityRequirement(name = "Authorization")}, parameters = @Parameter(name = "Authorization"))
     @Auth
     @GetMapping("/api/v1/member/stock")
     public ApiResponse<List<StockCalculateResponse>> getStocksInfo(@RequestParam StockMarketType type, @MemberId Long memberId) {
@@ -37,11 +37,11 @@ public class MemberStockRetrieveController {
         return ApiResponse.success(memberStockRetrieveService.getMemberInvestStatus(memberId));
     }
 
-    @Operation(summary = "내가 보유한 주식 전체를 조회 API (이전 캐시)", security = {@SecurityRequirement(name = "Authorization")}, parameters = @Parameter(name = "Authorization"))
+    @Operation(summary = "내가 보유한 주식 전체를 조회 API (캐싱된 정보)", security = {@SecurityRequirement(name = "Authorization")}, parameters = @Parameter(name = "Authorization"))
     @Auth
-    @GetMapping("/api/v1/member/stock/status/previous")
-    public ApiResponse<InvestStatusResponse> getMemberPreviousInvestStatus(@MemberId Long memberId) {
-        return ApiResponse.success(memberStockRetrieveService.getMemberPreviousInvestStatus(memberId));
+    @GetMapping("/api/v1/member/stock/status/history")
+    public ApiResponse<InvestStatusResponse> getLastMemberInvestStatusHistory(@MemberId Long memberId) {
+        return ApiResponse.success(memberStockRetrieveService.getLastMemberInvestStatusHistory(memberId));
     }
 
 }

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/controller/memberstock/MemberStockRetrieveController.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/controller/memberstock/MemberStockRetrieveController.java
@@ -37,4 +37,11 @@ public class MemberStockRetrieveController {
         return ApiResponse.success(memberStockRetrieveService.getMemberInvestStatus(memberId));
     }
 
+    @Operation(summary = "내가 보유한 주식 전체를 조회 API (이전 캐시)", security = {@SecurityRequirement(name = "Authorization")}, parameters = @Parameter(name = "Authorization"))
+    @Auth
+    @GetMapping("/api/v1/member/stock/status/previous")
+    public ApiResponse<InvestStatusResponse> getMemberPreviousInvestStatus(@MemberId Long memberId) {
+        return ApiResponse.success(memberStockRetrieveService.getMemberPreviousInvestStatus(memberId));
+    }
+
 }

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/controller/stockhistory/StockHistoryEventListener.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/controller/stockhistory/StockHistoryEventListener.java
@@ -1,0 +1,20 @@
+package com.depromeet.muyaho.api.controller.stockhistory;
+
+import com.depromeet.muyaho.api.event.memberstock.MemberStockDeletedEvent;
+import com.depromeet.muyaho.api.service.stockhistory.StockHistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class StockHistoryEventListener {
+
+    private final StockHistoryService stockHistoryService;
+
+    @EventListener
+    public void deleteMemberStockHistory(MemberStockDeletedEvent event) {
+        stockHistoryService.deleteMemberStockHistory(event.getMemberStockId(), event.getMemberId());
+    }
+
+}

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/event/memberstock/MemberStockDeletedEvent.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/event/memberstock/MemberStockDeletedEvent.java
@@ -1,0 +1,19 @@
+package com.depromeet.muyaho.api.event.memberstock;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberStockDeletedEvent {
+
+    private final Long memberStockId;
+
+    private final Long memberId;
+
+    public static MemberStockDeletedEvent of(Long memberStockId, Long memberId) {
+        return new MemberStockDeletedEvent(memberStockId, memberId);
+    }
+
+}

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/memberstock/MemberStockRetrieveService.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/memberstock/MemberStockRetrieveService.java
@@ -37,7 +37,7 @@ public class MemberStockRetrieveService {
         );
     }
 
-    public InvestStatusResponse getMemberPreviousInvestStatus(Long memberId) {
+    public InvestStatusResponse getLastMemberInvestStatusHistory(Long memberId) {
         return InvestStatusResponse.of(
             stockHistoryService.retrieveMemberStockHistory(StockMarketType.BITCOIN, memberId),
             stockHistoryService.retrieveMemberStockHistory(StockMarketType.DOMESTIC_STOCK, memberId),

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/memberstock/MemberStockRetrieveService.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/memberstock/MemberStockRetrieveService.java
@@ -1,6 +1,7 @@
 package com.depromeet.muyaho.api.service.memberstock;
 
 import com.depromeet.muyaho.api.service.memberstock.dto.response.InvestStatusResponse;
+import com.depromeet.muyaho.api.service.stockhistory.StockHistoryService;
 import com.depromeet.muyaho.domain.domain.memberstock.MemberStockCollection;
 import com.depromeet.muyaho.domain.domain.memberstock.MemberStockRepository;
 import com.depromeet.muyaho.domain.domain.stock.StockMarketType;
@@ -18,13 +19,14 @@ public class MemberStockRetrieveService {
 
     private final MemberStockRepository memberStockRepository;
     private final StockCalculator stockCalculator;
+    private final StockHistoryService stockHistoryService;
 
     public List<StockCalculateResponse> getMemberCurrentStocks(StockMarketType type, Long memberId) {
         MemberStockCollection collection = MemberStockCollection.of(memberStockRepository.findAllStocksByMemberIdAndType(memberId, type));
         if (collection.isEmpty()) {
             return Collections.emptyList();
         }
-        return stockCalculator.calculateCurrentMemberStocks(type, collection);
+        return stockCalculator.calculateCurrentMemberStocks(memberId, type, collection);
     }
 
     public InvestStatusResponse getMemberInvestStatus(Long memberId) {
@@ -32,6 +34,14 @@ public class MemberStockRetrieveService {
             getMemberCurrentStocks(StockMarketType.BITCOIN, memberId),
             getMemberCurrentStocks(StockMarketType.DOMESTIC_STOCK, memberId),
             getMemberCurrentStocks(StockMarketType.OVERSEAS_STOCK, memberId)
+        );
+    }
+
+    public InvestStatusResponse getMemberPreviousInvestStatus(Long memberId) {
+        return InvestStatusResponse.of(
+            stockHistoryService.retrieveMemberStockHistory(StockMarketType.BITCOIN, memberId),
+            stockHistoryService.retrieveMemberStockHistory(StockMarketType.DOMESTIC_STOCK, memberId),
+            stockHistoryService.retrieveMemberStockHistory(StockMarketType.OVERSEAS_STOCK, memberId)
         );
     }
 

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/memberstock/MemberStockService.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/memberstock/MemberStockService.java
@@ -1,5 +1,6 @@
 package com.depromeet.muyaho.api.service.memberstock;
 
+import com.depromeet.muyaho.api.event.memberstock.MemberStockDeletedEvent;
 import com.depromeet.muyaho.api.service.stock.StockServiceUtils;
 import com.depromeet.muyaho.domain.domain.memberstock.DeletedMemberSockRepository;
 import com.depromeet.muyaho.domain.domain.memberstock.MemberStock;
@@ -11,6 +12,7 @@ import com.depromeet.muyaho.api.service.memberstock.dto.request.DeleteMemberStoc
 import com.depromeet.muyaho.api.service.memberstock.dto.request.UpdateMemberStockRequest;
 import com.depromeet.muyaho.api.service.memberstock.dto.response.MemberStockInfoResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class MemberStockService {
 
+    private final ApplicationEventPublisher eventPublisher;
     private final MemberStockRepository memberStockRepository;
     private final StockRepository stockRepository;
     private final DeletedMemberSockRepository deletedMemberSockRepository;
@@ -39,6 +42,7 @@ public class MemberStockService {
     @Transactional
     public void deleteMemberStock(DeleteMemberStockRequest request, Long memberId) {
         MemberStock memberStock = MemberStockServiceUtils.findMemberStockByIdAndMemberId(memberStockRepository, request.getMemberStockId(), memberId);
+        eventPublisher.publishEvent(MemberStockDeletedEvent.of(request.getMemberStockId(), memberId));
         deletedMemberSockRepository.save(memberStock.delete());
         memberStockRepository.delete(memberStock);
     }

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/stockcalculator/StockCalculator.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/stockcalculator/StockCalculator.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 public interface StockCalculator {
 
-    List<StockCalculateResponse> calculateCurrentMemberStocks(StockMarketType type, MemberStockCollection collection);
+    List<StockCalculateResponse> calculateCurrentMemberStocks(Long memberId, StockMarketType type, MemberStockCollection collection);
 
 }

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/stockcalculator/StockCalculatorImpl.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/stockcalculator/StockCalculatorImpl.java
@@ -37,12 +37,12 @@ public class StockCalculatorImpl implements StockCalculator {
     public List<StockCalculateResponse> calculateCurrentMemberStocks(Long memberId, StockMarketType type, MemberStockCollection collection) {
         BigDecimal rate = exchangeRateApiCaller.fetchExchangeRate();
         if (type.isStockType()) {
-            return getStockCurrentInfo(memberId, type, collection, rate);
+            return getStockCurrentStatus(memberId, type, collection, rate);
         }
-        return getBitCoinCurrentInfo(memberId, type, collection, rate);
+        return getBitCoinCurrentStatus(memberId, type, collection, rate);
     }
 
-    private List<StockCalculateResponse> getStockCurrentInfo(Long memberId, StockMarketType type, MemberStockCollection collection, BigDecimal rate) {
+    private List<StockCalculateResponse> getStockCurrentStatus(Long memberId, StockMarketType type, MemberStockCollection collection, BigDecimal rate) {
         final Map<String, MemberStock> memberStockMap = collection.newMemberStockMap();
         List<StockPriceResponse> currentStockPrices = stockApiCaller.fetchCurrentStockPrice(collection.extractCodesWithDelimiter(DELIMITER));
 
@@ -57,7 +57,7 @@ public class StockCalculatorImpl implements StockCalculator {
         return stockHistoryService.renewMemberStockHistory(memberId, type, renewMemberStockHistoryRequests);
     }
 
-    private List<StockCalculateResponse> getBitCoinCurrentInfo(Long memberId, StockMarketType type, MemberStockCollection collection, BigDecimal rate) {
+    private List<StockCalculateResponse> getBitCoinCurrentStatus(Long memberId, StockMarketType type, MemberStockCollection collection, BigDecimal rate) {
         final Map<String, MemberStock> memberStockMap = collection.newMemberStockMap();
         List<UpBitPriceResponse> currentBitcoinPrices = upBitApiCaller.fetchCurrentBitcoinPrice(collection.extractCodesWithDelimiter(DELIMITER));
 

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/stockcalculator/dto/response/StockCalculateResponse.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/stockcalculator/dto/response/StockCalculateResponse.java
@@ -3,6 +3,7 @@ package com.depromeet.muyaho.api.service.stockcalculator.dto.response;
 import com.depromeet.muyaho.domain.domain.common.CurrencyType;
 import com.depromeet.muyaho.domain.domain.memberstock.MemberStock;
 import com.depromeet.muyaho.api.service.stock.dto.response.StockInfoResponse;
+import com.depromeet.muyaho.domain.domain.stockhistory.StockHistory;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -44,6 +45,19 @@ public class StockCalculateResponse {
             .quantity(roundFloor(memberStock.getQuantity()))
             .currencyType(memberStock.getCurrencyType())
             .profitOrLoseRate(roundFloor(profitOrLoseRate))
+            .build();
+    }
+
+    public static StockCalculateResponse of(StockHistory history) {
+        final MemberStock memberStock = history.getMemberStock();
+        return StockCalculateResponse.builder()
+            .memberStockId(memberStock.getId())
+            .stock(StockInfoResponse.of(memberStock.getStock()))
+            .purchase(StockPurchaseResponse.of(memberStock.getPurchaseUnitPrice(), memberStock.getQuantity(), memberStock.getPurchaseTotalPriceInWon()))
+            .current(StockCurrentResponse.of(memberStock.getQuantity(), history.getCurrentPriceInWon(), history.getCurrentPriceInDollar()))
+            .quantity(roundFloor(memberStock.getQuantity()))
+            .currencyType(memberStock.getCurrencyType())
+            .profitOrLoseRate(roundFloor(history.getProfitOrLoseRate()))
             .build();
     }
 

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/stockhistory/StockHistoryService.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/stockhistory/StockHistoryService.java
@@ -1,0 +1,41 @@
+package com.depromeet.muyaho.api.service.stockhistory;
+
+import com.depromeet.muyaho.api.service.stockcalculator.dto.response.StockCalculateResponse;
+import com.depromeet.muyaho.api.service.stockhistory.dto.request.RenewMemberStockHistoryRequest;
+import com.depromeet.muyaho.domain.domain.stock.StockMarketType;
+import com.depromeet.muyaho.domain.domain.stockhistory.StockHistory;
+import com.depromeet.muyaho.domain.domain.stockhistory.StockHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class StockHistoryService {
+
+    private final StockHistoryRepository stockHistoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<StockCalculateResponse> retrieveMemberStockHistory(StockMarketType type, Long memberId) {
+        return stockHistoryRepository.findAllByMemberIdAndType(memberId, type).stream()
+            .map(StockCalculateResponse::of)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<StockCalculateResponse> renewMemberStockHistory(Long memberId, StockMarketType type, List<RenewMemberStockHistoryRequest> requests) {
+        stockHistoryRepository.deleteAll(stockHistoryRepository.findAllByMemberIdAndType(memberId, type));
+
+        List<StockHistory> stockHistories = requests.stream()
+            .map(RenewMemberStockHistoryRequest::toEntity)
+            .collect(Collectors.toList());
+
+        return stockHistoryRepository.saveAll(stockHistories).stream()
+            .map(StockCalculateResponse::of)
+            .collect(Collectors.toList());
+    }
+
+}

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/stockhistory/StockHistoryService.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/stockhistory/StockHistoryService.java
@@ -20,7 +20,8 @@ public class StockHistoryService {
 
     @Transactional(readOnly = true)
     public List<StockCalculateResponse> retrieveMemberStockHistory(StockMarketType type, Long memberId) {
-        return stockHistoryRepository.findAllByMemberIdAndType(memberId, type).stream()
+        List<StockHistory> stockHistories = stockHistoryRepository.findAllByMemberIdAndType(memberId, type);
+        return stockHistories.stream()
             .map(StockCalculateResponse::of)
             .collect(Collectors.toList());
     }
@@ -36,6 +37,11 @@ public class StockHistoryService {
         return stockHistoryRepository.saveAll(stockHistories).stream()
             .map(StockCalculateResponse::of)
             .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteMemberStockHistory(Long memberStockId, Long memberId) {
+        stockHistoryRepository.deleteAll(stockHistoryRepository.findAllByMemberStockIdAndMemberId(memberStockId, memberId));
     }
 
 }

--- a/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/stockhistory/dto/request/RenewMemberStockHistoryRequest.java
+++ b/muyaho-api/src/main/java/com/depromeet/muyaho/api/service/stockhistory/dto/request/RenewMemberStockHistoryRequest.java
@@ -1,0 +1,39 @@
+package com.depromeet.muyaho.api.service.stockhistory.dto.request;
+
+import com.depromeet.muyaho.domain.domain.memberstock.MemberStock;
+import com.depromeet.muyaho.domain.domain.stockhistory.StockHistory;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RenewMemberStockHistoryRequest {
+
+    private MemberStock memberStock;
+    private BigDecimal currentPriceInWon;
+    private BigDecimal currentPriceInDollar;
+    private BigDecimal profitOrLoseRate;
+
+    public static RenewMemberStockHistoryRequest of(MemberStock memberStock, BigDecimal currentPriceInWon, BigDecimal currentPriceInDollar, BigDecimal profitOrLoseRate) {
+        return new RenewMemberStockHistoryRequest(memberStock, currentPriceInWon, currentPriceInDollar, profitOrLoseRate);
+    }
+
+    public static RenewMemberStockHistoryRequest testInstance(MemberStock memberStock, BigDecimal currentPriceInWon, BigDecimal currentPriceInDollar, BigDecimal profitOrLoseRate) {
+        return new RenewMemberStockHistoryRequest(memberStock, currentPriceInWon, currentPriceInDollar, profitOrLoseRate);
+    }
+
+    public StockHistory toEntity() {
+        return StockHistory.builder()
+            .memberStock(memberStock)
+            .currentPriceInWon(currentPriceInWon)
+            .currentPriceInDollar(currentPriceInDollar)
+            .profitOrLoseRate(profitOrLoseRate)
+            .build();
+    }
+
+}

--- a/muyaho-api/src/test/java/com/depromeet/muyaho/api/service/stockcalculator/StockCalculatorTest.java
+++ b/muyaho-api/src/test/java/com/depromeet/muyaho/api/service/stockcalculator/StockCalculatorTest.java
@@ -4,6 +4,7 @@ import com.depromeet.muyaho.api.service.stock.dto.response.StockInfoResponse;
 import com.depromeet.muyaho.api.service.stockcalculator.dto.response.StockCurrentPriceResponse;
 import com.depromeet.muyaho.api.service.stockcalculator.dto.response.StockPurchaseResponse;
 import com.depromeet.muyaho.api.service.stockcalculator.dto.response.StockCalculateResponse;
+import com.depromeet.muyaho.api.service.stockhistory.StockHistoryService;
 import com.depromeet.muyaho.domain.domain.common.CurrencyType;
 import com.depromeet.muyaho.domain.domain.memberstock.MemberStock;
 import com.depromeet.muyaho.domain.domain.memberstock.MemberStockCollection;
@@ -14,6 +15,7 @@ import com.depromeet.muyaho.domain.domain.stock.StockCreator;
 import com.depromeet.muyaho.domain.domain.stock.StockMarketType;
 import com.depromeet.muyaho.domain.domain.stock.StockRepository;
 import com.depromeet.muyaho.api.service.MemberSetupTest;
+import com.depromeet.muyaho.domain.domain.stockhistory.StockHistoryRepository;
 import com.depromeet.muyaho.external.client.bitcoin.upbit.UpBitApiCaller;
 import com.depromeet.muyaho.external.client.bitcoin.upbit.dto.response.UpBitCodesResponse;
 import com.depromeet.muyaho.external.client.bitcoin.upbit.dto.response.UpBitPriceResponse;
@@ -51,6 +53,12 @@ class StockCalculatorTest extends MemberSetupTest {
     @Autowired
     private MemberStockRepository memberStockRepository;
 
+    @Autowired
+    private StockHistoryService stockHistoryService;
+
+    @Autowired
+    private StockHistoryRepository stockHistoryRepository;
+
     private static final BigDecimal bitCoinCurrentPrice = new BigDecimal(1000);
     private static final BigDecimal stockCurrentPrice = new BigDecimal(3000);
     private static final BigDecimal currencyChangeRate = new BigDecimal(1000);
@@ -58,12 +66,13 @@ class StockCalculatorTest extends MemberSetupTest {
 
     @BeforeEach
     void setUpStock() {
-        stockCalculator = new StockCalculatorImpl(new StubUpBitApiCaller(), new StubStockApiCaller(), new StubExchangeAPiCaller());
+        stockCalculator = new StockCalculatorImpl(new StubUpBitApiCaller(), new StubStockApiCaller(), new StubExchangeAPiCaller(), stockHistoryService);
     }
 
     @AfterEach
     void cleanUp() {
         super.cleanup();
+        stockHistoryRepository.deleteAllInBatch();
         memberStockRepository.deleteAllInBatch();
         stockRepository.deleteAllInBatch();
     }
@@ -111,7 +120,7 @@ class StockCalculatorTest extends MemberSetupTest {
         MemberStockCollection collection = MemberStockCollection.of(Collections.singletonList(memberStock));
 
         // when
-        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(type, collection);
+        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(memberId, type, collection);
 
         // then
         assertThat(responses).hasSize(1);
@@ -130,7 +139,7 @@ class StockCalculatorTest extends MemberSetupTest {
         MemberStockCollection collection = MemberStockCollection.of(Collections.singletonList(memberStock));
 
         // when
-        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(type, collection);
+        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(memberId, type, collection);
 
         // then
         assertThat(responses).hasSize(1);
@@ -157,7 +166,7 @@ class StockCalculatorTest extends MemberSetupTest {
         MemberStockCollection collection = MemberStockCollection.of(Collections.singletonList(memberStock));
 
         // when
-        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(StockMarketType.BITCOIN, collection);
+        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(memberId, StockMarketType.BITCOIN, collection);
 
         // then
         assertThat(responses).hasSize(1);
@@ -176,7 +185,7 @@ class StockCalculatorTest extends MemberSetupTest {
         MemberStockCollection collection = MemberStockCollection.of(Collections.singletonList(memberStock));
 
         // when
-        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(StockMarketType.BITCOIN, collection);
+        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(memberId, StockMarketType.BITCOIN, collection);
 
         // then
         assertThat(responses).hasSize(1);
@@ -196,7 +205,7 @@ class StockCalculatorTest extends MemberSetupTest {
         MemberStockCollection collection = MemberStockCollection.of(Collections.singletonList(memberStock));
 
         // when
-        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(StockMarketType.DOMESTIC_STOCK, collection);
+        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(memberId, StockMarketType.DOMESTIC_STOCK, collection);
 
         // then
         assertThat(responses).hasSize(1);
@@ -215,7 +224,7 @@ class StockCalculatorTest extends MemberSetupTest {
         MemberStockCollection collection = MemberStockCollection.of(Collections.singletonList(memberStock));
 
         // when
-        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(StockMarketType.DOMESTIC_STOCK, collection);
+        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(memberId, StockMarketType.DOMESTIC_STOCK, collection);
 
         // then
         assertThat(responses).hasSize(1);
@@ -235,7 +244,7 @@ class StockCalculatorTest extends MemberSetupTest {
         MemberStockCollection collection = MemberStockCollection.of(Collections.singletonList(memberStock));
 
         // when
-        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(StockMarketType.OVERSEAS_STOCK, collection);
+        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(memberId, StockMarketType.OVERSEAS_STOCK, collection);
 
         // then
         assertThat(responses).hasSize(1);
@@ -255,7 +264,7 @@ class StockCalculatorTest extends MemberSetupTest {
         MemberStockCollection collection = MemberStockCollection.of(Collections.singletonList(memberStock));
 
         // when
-        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(StockMarketType.OVERSEAS_STOCK, collection);
+        List<StockCalculateResponse> responses = stockCalculator.calculateCurrentMemberStocks(memberId, StockMarketType.OVERSEAS_STOCK, collection);
 
         // then
         assertThat(responses).hasSize(1);

--- a/muyaho-api/src/test/java/com/depromeet/muyaho/api/service/stockhistory/StockHistoryTest.java
+++ b/muyaho-api/src/test/java/com/depromeet/muyaho/api/service/stockhistory/StockHistoryTest.java
@@ -116,6 +116,27 @@ class StockHistoryTest extends MemberSetupTest {
         assertStockHistory(stockHistoryList.get(0), currentPriceInWon, currentPriceInDollar, profitOrLoseRate);
     }
 
+    @Test
+    void 해당하는_memberStock_id와_memberId를_가진_StockHistory를_모두_제거한다() {
+        // given
+        Stock stock = StockCreator.createActive("code", "name", StockMarketType.DOMESTIC_STOCK);
+        stockRepository.save(stock);
+        MemberStock memberStock = MemberStockCreator.create(memberId, stock, new BigDecimal(1000), new BigDecimal(10));
+        memberStockRepository.save(memberStock);
+
+        BigDecimal currentPriceInWon = new BigDecimal(1000);
+        BigDecimal currentPriceInDollar = new BigDecimal(1);
+        BigDecimal profitOrLoseRate = new BigDecimal(30);
+        stockHistoryRepository.save(StockHistoryCreator.create(memberStock, currentPriceInWon, currentPriceInDollar, profitOrLoseRate));
+
+        // when
+        stockHistoryService.deleteMemberStockHistory(memberStock.getId(), memberId);
+
+        // then
+        List<StockHistory> stockHistoryList = stockHistoryRepository.findAll();
+        assertThat(stockHistoryList).isEmpty();
+    }
+
     private void assertStockHistory(StockHistory stockHistory, BigDecimal currentPriceInWon, BigDecimal currentPriceInDollar, BigDecimal profitOrLoseRate) {
         assertThat(stockHistory.getCurrentPriceInWon()).isEqualByComparingTo(currentPriceInWon);
         assertThat(stockHistory.getCurrentPriceInDollar()).isEqualByComparingTo(currentPriceInDollar);

--- a/muyaho-api/src/test/java/com/depromeet/muyaho/api/service/stockhistory/StockHistoryTest.java
+++ b/muyaho-api/src/test/java/com/depromeet/muyaho/api/service/stockhistory/StockHistoryTest.java
@@ -1,0 +1,125 @@
+package com.depromeet.muyaho.api.service.stockhistory;
+
+import com.depromeet.muyaho.api.service.MemberSetupTest;
+import com.depromeet.muyaho.api.service.stockhistory.dto.request.RenewMemberStockHistoryRequest;
+import com.depromeet.muyaho.domain.domain.memberstock.MemberStock;
+import com.depromeet.muyaho.domain.domain.memberstock.MemberStockCreator;
+import com.depromeet.muyaho.domain.domain.memberstock.MemberStockRepository;
+import com.depromeet.muyaho.domain.domain.stock.Stock;
+import com.depromeet.muyaho.domain.domain.stock.StockCreator;
+import com.depromeet.muyaho.domain.domain.stock.StockMarketType;
+import com.depromeet.muyaho.domain.domain.stock.StockRepository;
+import com.depromeet.muyaho.domain.domain.stockhistory.StockHistory;
+import com.depromeet.muyaho.domain.domain.stockhistory.StockHistoryCreator;
+import com.depromeet.muyaho.domain.domain.stockhistory.StockHistoryRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class StockHistoryTest extends MemberSetupTest {
+
+    @Autowired
+    private StockHistoryService stockHistoryService;
+
+    @Autowired
+    private MemberStockRepository memberStockRepository;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Autowired
+    private StockHistoryRepository stockHistoryRepository;
+
+    @AfterEach
+    void cleanUp() {
+        super.cleanup();
+        stockHistoryRepository.deleteAllInBatch();
+        memberStockRepository.deleteAllInBatch();
+        stockRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 멤버가_조회한_주식_결과를_저장해둔다() {
+        // given
+        Stock stock = StockCreator.createActive("code", "name", StockMarketType.DOMESTIC_STOCK);
+        stockRepository.save(stock);
+        MemberStock memberStock = MemberStockCreator.create(memberId, stock, new BigDecimal(1000), new BigDecimal(10));
+        memberStockRepository.save(memberStock);
+
+        BigDecimal currentPriceInWon = new BigDecimal(1000);
+        BigDecimal currentPriceInDollar = new BigDecimal(1);
+        BigDecimal profitOrLoseRate = new BigDecimal(30);
+
+        RenewMemberStockHistoryRequest request = RenewMemberStockHistoryRequest.testInstance(memberStock, currentPriceInWon, currentPriceInDollar, profitOrLoseRate);
+
+        // when
+        stockHistoryService.renewMemberStockHistory(memberId, StockMarketType.DOMESTIC_STOCK, Collections.singletonList(request));
+
+        // then
+        List<StockHistory> stockHistoryList = stockHistoryRepository.findAll();
+        assertThat(stockHistoryList).hasSize(1);
+        assertStockHistory(stockHistoryList.get(0), currentPriceInWon, currentPriceInDollar, profitOrLoseRate);
+    }
+
+    @Test
+    void 멤버가_조회한_주식결과를_갱신하면_같은_주식_타입의기존의_기록은_지워진다() {
+        // given
+        Stock stock = StockCreator.createActive("code", "name", StockMarketType.DOMESTIC_STOCK);
+        stockRepository.save(stock);
+        MemberStock memberStock = MemberStockCreator.create(memberId, stock, new BigDecimal(1000), new BigDecimal(10));
+        memberStockRepository.save(memberStock);
+
+        stockHistoryRepository.save(StockHistoryCreator.create(memberStock, new BigDecimal(2000), new BigDecimal(2), new BigDecimal(40)));
+
+        BigDecimal currentPriceInWon = new BigDecimal(1000);
+        BigDecimal currentPriceInDollar = new BigDecimal(1);
+        BigDecimal profitOrLoseRate = new BigDecimal(30);
+
+        RenewMemberStockHistoryRequest request = RenewMemberStockHistoryRequest.testInstance(memberStock, currentPriceInWon, currentPriceInDollar, profitOrLoseRate);
+
+        // when
+        stockHistoryService.renewMemberStockHistory(memberId, StockMarketType.DOMESTIC_STOCK, Collections.singletonList(request));
+
+        // then
+        List<StockHistory> stockHistoryList = stockHistoryRepository.findAll();
+        assertThat(stockHistoryList).hasSize(1);
+        assertStockHistory(stockHistoryList.get(0), currentPriceInWon, currentPriceInDollar, profitOrLoseRate);
+    }
+
+    @Test
+    void 주식_기록을_갱신할때_다른_주식_타입의_주식_기록들은_지워지지_않는다() {
+        // given
+        Stock stock = StockCreator.createActive("code", "name", StockMarketType.DOMESTIC_STOCK);
+        stockRepository.save(stock);
+        MemberStock memberStock = MemberStockCreator.create(memberId, stock, new BigDecimal(1000), new BigDecimal(10));
+        memberStockRepository.save(memberStock);
+
+        BigDecimal currentPriceInWon = new BigDecimal(1000);
+        BigDecimal currentPriceInDollar = new BigDecimal(1);
+        BigDecimal profitOrLoseRate = new BigDecimal(30);
+        stockHistoryRepository.save(StockHistoryCreator.create(memberStock, currentPriceInWon, currentPriceInDollar, profitOrLoseRate));
+
+        // when
+        stockHistoryService.renewMemberStockHistory(memberId, StockMarketType.BITCOIN, Collections.emptyList());
+
+        // then
+        List<StockHistory> stockHistoryList = stockHistoryRepository.findAll();
+        assertThat(stockHistoryList).hasSize(1);
+        assertStockHistory(stockHistoryList.get(0), currentPriceInWon, currentPriceInDollar, profitOrLoseRate);
+    }
+
+    private void assertStockHistory(StockHistory stockHistory, BigDecimal currentPriceInWon, BigDecimal currentPriceInDollar, BigDecimal profitOrLoseRate) {
+        assertThat(stockHistory.getCurrentPriceInWon()).isEqualByComparingTo(currentPriceInWon);
+        assertThat(stockHistory.getCurrentPriceInDollar()).isEqualByComparingTo(currentPriceInDollar);
+        assertThat(stockHistory.getProfitOrLoseRate()).isEqualByComparingTo(profitOrLoseRate);
+    }
+
+}

--- a/muyaho-common/src/main/java/com/depromeet/muyaho/common/utils/BigDecimalUtils.java
+++ b/muyaho-common/src/main/java/com/depromeet/muyaho/common/utils/BigDecimalUtils.java
@@ -15,6 +15,9 @@ public class BigDecimalUtils {
     }
 
     public static BigDecimal calculateDifferencePercent(BigDecimal benchMark, BigDecimal target) {
+        if (target.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
         if (benchMark.compareTo(target) >= 0) {
             return benchMark.subtract(target)
                 .divide(target, new MathContext(2))

--- a/muyaho-domain/build.gradle
+++ b/muyaho-domain/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     api group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '2.3.8.RELEASE'
 
-    runtimeOnly 'com.h2database:h2'
+    implementation 'com.h2database:h2'
     runtimeOnly group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.6.2'
 
     implementation "com.querydsl:querydsl-jpa"

--- a/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/config/H2ServerConfig.java
+++ b/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/config/H2ServerConfig.java
@@ -1,0 +1,19 @@
+package com.depromeet.muyaho.domain.config;
+
+import org.h2.tools.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.sql.SQLException;
+
+@Profile("local")
+@Configuration
+public class H2ServerConfig {
+
+    @Bean
+    public Server h2TcpServer() throws SQLException {
+        return Server.createTcpServer().start();
+    }
+
+}

--- a/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/StockHistory.java
+++ b/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/StockHistory.java
@@ -1,0 +1,40 @@
+package com.depromeet.muyaho.domain.domain.stockhistory;
+
+import com.depromeet.muyaho.domain.domain.BaseTimeEntity;
+import com.depromeet.muyaho.domain.domain.memberstock.MemberStock;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class StockHistory extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_stock_id", nullable = false)
+    private MemberStock memberStock;
+
+    private BigDecimal currentPriceInWon;
+
+    private BigDecimal currentPriceInDollar;
+
+    private BigDecimal profitOrLoseRate;
+
+    @Builder
+    public StockHistory(MemberStock memberStock, BigDecimal currentPriceInWon, BigDecimal currentPriceInDollar, BigDecimal profitOrLoseRate) {
+        this.memberStock = memberStock;
+        this.currentPriceInWon = currentPriceInWon;
+        this.currentPriceInDollar = currentPriceInDollar;
+        this.profitOrLoseRate = profitOrLoseRate;
+    }
+
+}

--- a/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/StockHistoryCreator.java
+++ b/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/StockHistoryCreator.java
@@ -1,0 +1,18 @@
+package com.depromeet.muyaho.domain.domain.stockhistory;
+
+import com.depromeet.muyaho.domain.domain.memberstock.MemberStock;
+
+import java.math.BigDecimal;
+
+public class StockHistoryCreator {
+
+    public static StockHistory create(MemberStock memberStock, BigDecimal currentPriceInWon, BigDecimal currentPriceInDollar, BigDecimal profitOrLoseRate) {
+        return StockHistory.builder()
+            .memberStock(memberStock)
+            .currentPriceInWon(currentPriceInWon)
+            .currentPriceInDollar(currentPriceInDollar)
+            .profitOrLoseRate(profitOrLoseRate)
+            .build();
+    }
+
+}

--- a/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/StockHistoryRepository.java
+++ b/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/StockHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.depromeet.muyaho.domain.domain.stockhistory;
+
+import com.depromeet.muyaho.domain.domain.stockhistory.repository.StockHistoryRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockHistoryRepository extends JpaRepository<StockHistory, Long>, StockHistoryRepositoryCustom {
+
+}

--- a/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/repository/StockHistoryRepositoryCustom.java
+++ b/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/repository/StockHistoryRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.depromeet.muyaho.domain.domain.stockhistory.repository;
+
+import com.depromeet.muyaho.domain.domain.stock.StockMarketType;
+import com.depromeet.muyaho.domain.domain.stockhistory.StockHistory;
+
+import java.util.List;
+
+public interface StockHistoryRepositoryCustom {
+
+    List<StockHistory> findAllByMemberIdAndType(Long memberId, StockMarketType type);
+
+}

--- a/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/repository/StockHistoryRepositoryCustom.java
+++ b/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/repository/StockHistoryRepositoryCustom.java
@@ -9,4 +9,6 @@ public interface StockHistoryRepositoryCustom {
 
     List<StockHistory> findAllByMemberIdAndType(Long memberId, StockMarketType type);
 
+    List<StockHistory> findAllByMemberStockIdAndMemberId(Long memberStockId, Long memberId);
+
 }

--- a/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/repository/StockHistoryRepositoryCustomImpl.java
+++ b/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/repository/StockHistoryRepositoryCustomImpl.java
@@ -25,4 +25,14 @@ public class StockHistoryRepositoryCustomImpl implements StockHistoryRepositoryC
             ).fetch();
     }
 
+    @Override
+    public List<StockHistory> findAllByMemberStockIdAndMemberId(Long memberStockId, Long memberId) {
+        return queryFactory.selectFrom(stockHistory)
+            .innerJoin(stockHistory.memberStock, memberStock).fetchJoin()
+            .where(
+                stockHistory.memberStock.id.eq(memberStockId),
+                stockHistory.memberStock.memberId.eq(memberId)
+            ).fetch();
+    }
+
 }

--- a/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/repository/StockHistoryRepositoryCustomImpl.java
+++ b/muyaho-domain/src/main/java/com/depromeet/muyaho/domain/domain/stockhistory/repository/StockHistoryRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package com.depromeet.muyaho.domain.domain.stockhistory.repository;
+
+import com.depromeet.muyaho.domain.domain.stock.StockMarketType;
+import com.depromeet.muyaho.domain.domain.stockhistory.StockHistory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.depromeet.muyaho.domain.domain.stockhistory.QStockHistory.stockHistory;
+import static com.depromeet.muyaho.domain.domain.memberstock.QMemberStock.memberStock;
+
+@RequiredArgsConstructor
+public class StockHistoryRepositoryCustomImpl implements StockHistoryRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<StockHistory> findAllByMemberIdAndType(Long memberId, StockMarketType type) {
+        return queryFactory.selectFrom(stockHistory)
+            .innerJoin(stockHistory.memberStock, memberStock).fetchJoin()
+            .where(
+                stockHistory.memberStock.memberId.eq(memberId),
+                stockHistory.memberStock.stock.type.eq(type)
+            ).fetch();
+    }
+
+}


### PR DESCRIPTION
### 문제점
해외주식의 경우 현재가를 조회할때 속도가 너무 오래걸리는 문제 존재.

### 기능
이전의 전체의 보유 주식 기록 조회한 것을 캐싱해두고, 먼저 반환해주고, 갱신이 완료되면 그 결과값을 보여주도록.

클라이언트 -> 서버로 사용자의 보유 주식 현재 가격 요청시
1. 이전 기록의 캐싱된 정보를 일단 보여주고
2. 실제로 외부 API를 통해서 가져온 정보를 캐싱해두고, 그 값을 보여준다.